### PR TITLE
Restore original body overflow setting

### DIFF
--- a/zoomable.js
+++ b/zoomable.js
@@ -28,6 +28,7 @@
       // Create components
       var img       = createImgComponent(options);
       var container = createContainerComponent(options, img);
+      var original_overflow = $('html, body').css('overflow');
 
       // Thumb click event (shows full size image)
       $(this).click(function() {
@@ -77,7 +78,7 @@
         }
 
         // Re-enable body scrolling once image hidden
-        enableBodyScroll();
+        enableBodyScroll(original_overflow);
       });
 
     });
@@ -286,10 +287,10 @@
   /**
    * Enables scrolling on the DOM body and shows the scrollbar
    */
-  function enableBodyScroll() {
+  function enableBodyScroll(setting) {
     // Disable body scrolling
     $('html, body').css({
-      'overflow': 'auto',
+      'overflow': setting,
     });
   }  
 


### PR DESCRIPTION
I really like this plugin but it caused a small problem by creating a horizontal scroll when enableBodyScroll set overflow to auto.  

I added a variable to get the original body overflow setting when the plugin fires for the first time. Instead of setting to auto when the picture is escaped, it restores it back to whatever the original was. Default setting is visible if none is found.